### PR TITLE
[calamares/PKGBUILD] update pkgver, fix source line, update release name + dependency name changes

### DIFF
--- a/calamares/PKGBUILD
+++ b/calamares/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=calamares
 pkgver=23.10.1.4
-pkgrel=1
+pkgrel=2
 release_name="Galileo"
 pkgdesc="Calamares installer for EndeavourOS"
 arch=('x86_64' 'aarch64')
@@ -12,9 +12,9 @@ url="https://github.com/endeavouros-team/calamares"
 license=('GPL3')
 makedepends=('git' 'cmake' 'extra-cmake-modules' 'kpmcore' 'boost' 'python-jsonschema' 'python-pyaml' 'python-unidecode' 'gawk')
 conflicts=('calamares_current')
-depends=( 'qt5-svg' 'qt5-webengine' 'yaml-cpp' 'networkmanager' 'upower' 'kcoreaddons' 'kconfig' 'ki18n' 'kservice' \
-'kwidgetsaddons' 'kpmcore' 'squashfs-tools' 'rsync' 'cryptsetup' 'qt5-xmlpatterns' 'doxygen' 'dmidecode' \
-'gptfdisk' 'kparts' 'polkit-qt5' 'python' 'solid' 'qt5-tools' 'boost-libs' 'libpwquality' 'ckbcomp' 'qt5-quickcontrols2' )
+depends=( 'qt5-svg' 'qt5-webengine' 'yaml-cpp' 'networkmanager' 'upower' 'kcoreaddons5' 'kconfig5' 'ki18n5' 'kservice5' \
+'kwidgetsaddons5' 'kpmcore' 'squashfs-tools' 'rsync' 'cryptsetup' 'qt5-xmlpatterns' 'doxygen' 'dmidecode' \
+'gptfdisk' 'hwinfo' 'kparts5' 'polkit-qt5' 'python' 'solid5' 'qt5-tools' 'boost-libs' 'libpwquality' 'ckbcomp' 'qt5-quickcontrols2' )
 provides=("calamares")
 options=(!strip !emptydirs)
 source=("https://github.com/endeavouros-team/${pkgname}/archive/refs/tags/${pkgver}-arm.tar.gz")

--- a/calamares/PKGBUILD
+++ b/calamares/PKGBUILD
@@ -3,9 +3,9 @@
 # Calamares installer configured for EndeavourOS
 
 pkgname=calamares
-pkgver=23.10.1.2
+pkgver=23.10.1.4
 pkgrel=1
-release_name="Cassini"
+release_name="Galileo"
 pkgdesc="Calamares installer for EndeavourOS"
 arch=('x86_64' 'aarch64')
 url="https://github.com/endeavouros-team/calamares"
@@ -17,9 +17,9 @@ depends=( 'qt5-svg' 'qt5-webengine' 'yaml-cpp' 'networkmanager' 'upower' 'kcorea
 'gptfdisk' 'kparts' 'polkit-qt5' 'python' 'solid' 'qt5-tools' 'boost-libs' 'libpwquality' 'ckbcomp' 'qt5-quickcontrols2' )
 provides=("calamares")
 options=(!strip !emptydirs)
-source=("https://github.com/endeavouros-team/${pkgname}/archive/refs/tags/${pkgver}.tar.gz")
+source=("https://github.com/endeavouros-team/${pkgname}/archive/refs/tags/${pkgver}-arm.tar.gz")
 
-sha256sums=('8fb5c2801cf0f947d37e22617af6be05341fcc5ae1a6a0c6a6ccb64ef5f75c78')
+sha256sums=('696a2b942062ff675e46298b13bccc4457ab150419a6ec06e3d81d0d17b32d1b')
 prepare() {
     # Update branding.desc with the proper values
     replace_command='


### PR DESCRIPTION
changing PKGBUILD to use the new arm calamares branch here:
https://github.com/endeavouros-team/calamares/tree/arm

Tags are set apart  from x64  by adding -arm to the version number e.g.:

[23.10.1.4-arm](https://github.com/endeavouros-team/calamares/releases/tag/23.10.1.4-arm)

